### PR TITLE
Removed step that tries to download non-existent artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           sdk: stable
 
-      - name: Download Changelog
-        uses: actions/download-artifact@v4
-        with:
-          name: changelog
-
       - name: Cache dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Should fix this issue: https://github.com/microsoft/kiota-dart/actions/runs/12634749936/job/35203187082#step:4:13