### PR TITLE
Allow meta 1.15.0 as it is compatible with the current stable version of flutter

### DIFF
--- a/packages/microsoft_kiota_abstractions/pubspec.yaml
+++ b/packages/microsoft_kiota_abstractions/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  meta: ^1.16.0
+  meta: ^1.15.0
   std_uritemplate: ^2.0.1
   uuid: ^4.5.1
 


### PR DESCRIPTION
This way, we can use the libraries with Flutter 3.27.1.