### PR TITLE
fix: check for null in getBoolValue

### DIFF
--- a/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
@@ -13,7 +13,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   bool? getBoolValue() {
-    return _node as bool;
+    return _node == null ? null : _node as bool;
   }
 
   @override

--- a/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
+++ b/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
@@ -189,5 +189,17 @@ void main() {
       expect(testCollection.first, 2);
       expect(testCollection.last, 5);
     });
+
+    test('getBoolValue', () {
+      final jsonParseNode = JsonParseNode(jsonDecode('true'));
+
+      expect(jsonParseNode.getBoolValue(), equals(true));
+    });
+
+    test('getBoolValue with null', () {
+      final jsonParseNode = JsonParseNode(null);
+
+      expect(jsonParseNode.getBoolValue(), equals(null));
+    });    
   });
 }

--- a/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
+++ b/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
@@ -200,6 +200,6 @@ void main() {
       final jsonParseNode = JsonParseNode(null);
 
       expect(jsonParseNode.getBoolValue(), equals(null));
-    });    
+    });
   });
 }

--- a/packages/microsoft_kiota_serialization_text/test/text_parse_node_test.dart
+++ b/packages/microsoft_kiota_serialization_text/test/text_parse_node_test.dart
@@ -37,6 +37,12 @@ void main() {
       expect(node.getBoolValue(), equals(true));
     });
 
+    test('getBoolValue with null', () {
+      final node = TextParseNode(null);
+
+      expect(node.getBoolValue(), equals(null));
+    });
+    
     test('getByteArrayValue', () {
       final node = TextParseNode('dGVzdA==');
 

--- a/packages/microsoft_kiota_serialization_text/test/text_parse_node_test.dart
+++ b/packages/microsoft_kiota_serialization_text/test/text_parse_node_test.dart
@@ -42,7 +42,7 @@ void main() {
 
       expect(node.getBoolValue(), equals(null));
     });
-    
+
     test('getByteArrayValue', () {
       final node = TextParseNode('dGVzdA==');
 


### PR DESCRIPTION
Add a missing NULL check which prevents a Dart exception using the MSGRAPH "me/messages" call.