### PR TITLE
fix: Fix nullable primitive responses

### DIFF
--- a/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
+++ b/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
@@ -1,5 +1,8 @@
 part of '../microsoft_kiota_http.dart';
 
+/// A helper to get a [Type] from a nullable generic parameter.
+typedef _TypeOf<T> = T;
+
 class HttpClientRequestAdapter implements RequestAdapter {
   HttpClientRequestAdapter({
     required AuthenticationProvider authProvider,
@@ -242,9 +245,11 @@ class HttpClientRequestAdapter implements RequestAdapter {
     await _throwIfFailedResponse(response, errorMapping);
   }
 
+  /// Checks if [T] is exactly [U] or [U?].
   @pragma('vm:prefer-inline')
-  bool _isExactly<T, U>() => T == U;
+  bool _isA<T, U>() => T == U || T == _TypeOf<U?>;
 
+  /// A hacky way to check if [T] is a exactly or a subtype of [U].
   @pragma('vm:prefer-inline')
   bool _isSubtype<T, U>() => <T>[] is List<U>;
 
@@ -260,28 +265,23 @@ class HttpClientRequestAdapter implements RequestAdapter {
       return null;
     }
 
-    if (_isExactly<ModelType, bool>() || _isExactly<ModelType, bool?>()) {
+    if (_isA<ModelType, bool>()) {
       return rootNode.getBoolValue() as ModelType;
-    } else if (_isExactly<ModelType, int>() || _isExactly<ModelType, int?>()) {
+    } else if (_isA<ModelType, int>()) {
       return rootNode.getIntValue() as ModelType;
-    } else if (_isExactly<ModelType, double>() ||
-        _isExactly<ModelType, double?>()) {
+    } else if (_isA<ModelType, double>()) {
       return rootNode.getDoubleValue() as ModelType;
-    } else if (_isExactly<ModelType, String>() ||
-        _isExactly<ModelType, String?>()) {
+    } else if (_isA<ModelType, String>()) {
       return rootNode.getStringValue() as ModelType;
-    } else if (_isExactly<ModelType, DateTime>() ||
-        _isExactly<ModelType, DateTime?>()) {
+    } else if (_isA<ModelType, DateTime>()) {
       return rootNode.getDateTimeValue() as ModelType;
     } else if (_isSubtype<ModelType, DateOnly?>()) {
       return rootNode.getDateOnlyValue() as ModelType;
     } else if (_isSubtype<ModelType, TimeOnly?>()) {
       return rootNode.getTimeOnlyValue() as ModelType;
-    } else if (_isExactly<ModelType, Duration>() ||
-        _isExactly<ModelType, Duration?>()) {
+    } else if (_isA<ModelType, Duration>()) {
       return rootNode.getDurationValue() as ModelType;
-    } else if (_isExactly<ModelType, UuidValue>() ||
-        _isExactly<ModelType, UuidValue?>()) {
+    } else if (_isA<ModelType, UuidValue>()) {
       return rootNode.getGuidValue() as ModelType;
     } else {
       throw ArgumentError(

--- a/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
+++ b/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
@@ -242,6 +242,12 @@ class HttpClientRequestAdapter implements RequestAdapter {
     await _throwIfFailedResponse(response, errorMapping);
   }
 
+  @pragma('vm:prefer-inline')
+  bool _isExactly<T, U>() => T == U;
+
+  @pragma('vm:prefer-inline')
+  bool _isSubtype<T, U>() => <T>[] is List<U>;
+
   @override
   Future<ModelType?> sendPrimitive<ModelType>(
     RequestInformation requestInfo, [
@@ -254,29 +260,28 @@ class HttpClientRequestAdapter implements RequestAdapter {
       return null;
     }
 
-    switch (ModelType) {
-      case const (bool):
-        return rootNode.getBoolValue() as ModelType;
-      case const (int):
-        return rootNode.getIntValue() as ModelType;
-      case const (double):
-        return rootNode.getDoubleValue() as ModelType;
-      case const (String):
-        return rootNode.getStringValue() as ModelType;
-      case const (DateTime):
-        return rootNode.getDateTimeValue() as ModelType;
-      case const (DateOnly):
-        return rootNode.getDateOnlyValue() as ModelType;
-      case const (TimeOnly):
-        return rootNode.getTimeOnlyValue() as ModelType;
-      case const (Duration):
-        return rootNode.getDurationValue() as ModelType;
-      case const (UuidValue):
-        return rootNode.getGuidValue() as ModelType;
-      default:
-        throw ArgumentError(
-          'The type $ModelType is not supported for primitive deserialization',
-        );
+    if (_isExactly<ModelType, bool>() || _isExactly<ModelType, bool?>()) {
+      return rootNode.getBoolValue() as ModelType;
+    } else if (_isExactly<ModelType, int>() || _isExactly<ModelType, int?>()) {
+      return rootNode.getIntValue() as ModelType;
+    } else if (_isExactly<ModelType, double>() || _isExactly<ModelType, double?>()) {
+      return rootNode.getDoubleValue() as ModelType;
+    } else if (_isExactly<ModelType, String>() || _isExactly<ModelType, String?>()) {
+      return rootNode.getStringValue() as ModelType;
+    } else if (_isExactly<ModelType, DateTime>() || _isExactly<ModelType, DateTime?>()) {
+      return rootNode.getDateTimeValue() as ModelType;
+    } else if (_isExactly<ModelType, DateOnly>() || _isExactly<ModelType, DateOnly?>() || _isSubtype<ModelType, DateOnly?>()) {
+      return rootNode.getDateOnlyValue() as ModelType;
+    } else if (_isExactly<ModelType, TimeOnly>() || _isExactly<ModelType, TimeOnly?>() || _isSubtype<ModelType, TimeOnly?>()) {
+      return rootNode.getTimeOnlyValue() as ModelType;
+    } else if (_isExactly<ModelType, Duration>() || _isExactly<ModelType, Duration?>()) {
+      return rootNode.getDurationValue() as ModelType;
+    } else if (_isExactly<ModelType, UuidValue>() || _isExactly<ModelType, UuidValue?>()) {
+      return rootNode.getGuidValue() as ModelType;
+    } else {
+      throw ArgumentError(
+        'The type $ModelType is not supported for primitive deserialization',
+      );
     }
   }
 

--- a/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
+++ b/packages/microsoft_kiota_http/lib/src/http_client_request_adapter.dart
@@ -264,19 +264,24 @@ class HttpClientRequestAdapter implements RequestAdapter {
       return rootNode.getBoolValue() as ModelType;
     } else if (_isExactly<ModelType, int>() || _isExactly<ModelType, int?>()) {
       return rootNode.getIntValue() as ModelType;
-    } else if (_isExactly<ModelType, double>() || _isExactly<ModelType, double?>()) {
+    } else if (_isExactly<ModelType, double>() ||
+        _isExactly<ModelType, double?>()) {
       return rootNode.getDoubleValue() as ModelType;
-    } else if (_isExactly<ModelType, String>() || _isExactly<ModelType, String?>()) {
+    } else if (_isExactly<ModelType, String>() ||
+        _isExactly<ModelType, String?>()) {
       return rootNode.getStringValue() as ModelType;
-    } else if (_isExactly<ModelType, DateTime>() || _isExactly<ModelType, DateTime?>()) {
+    } else if (_isExactly<ModelType, DateTime>() ||
+        _isExactly<ModelType, DateTime?>()) {
       return rootNode.getDateTimeValue() as ModelType;
-    } else if (_isExactly<ModelType, DateOnly>() || _isExactly<ModelType, DateOnly?>() || _isSubtype<ModelType, DateOnly?>()) {
+    } else if (_isSubtype<ModelType, DateOnly?>()) {
       return rootNode.getDateOnlyValue() as ModelType;
-    } else if (_isExactly<ModelType, TimeOnly>() || _isExactly<ModelType, TimeOnly?>() || _isSubtype<ModelType, TimeOnly?>()) {
+    } else if (_isSubtype<ModelType, TimeOnly?>()) {
       return rootNode.getTimeOnlyValue() as ModelType;
-    } else if (_isExactly<ModelType, Duration>() || _isExactly<ModelType, Duration?>()) {
+    } else if (_isExactly<ModelType, Duration>() ||
+        _isExactly<ModelType, Duration?>()) {
       return rootNode.getDurationValue() as ModelType;
-    } else if (_isExactly<ModelType, UuidValue>() || _isExactly<ModelType, UuidValue?>()) {
+    } else if (_isExactly<ModelType, UuidValue>() ||
+        _isExactly<ModelType, UuidValue?>()) {
       return rootNode.getGuidValue() as ModelType;
     } else {
       throw ArgumentError(

--- a/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
+++ b/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
@@ -109,5 +109,51 @@ void main() {
       expect(stringResult, isNotNull);
       expect(stringResult, stringContent);
     });
+
+    test('sendPrimitive throws for unsupported types', () async {
+      final client = MockClient();
+      final authProvider = MockAuthenticationProvider();
+      final pNodeFactory = MockParseNodeFactory();
+      final sWriterFactory = MockSerializationWriterFactory();
+      final parseNode = MockParseNode();
+
+      const stringContent = 'Hello, World!';
+      final contentBytes = Uint8List.fromList(stringContent.codeUnits);
+
+      final adapter = HttpClientRequestAdapter(
+        authProvider: authProvider,
+        pNodeFactory: pNodeFactory,
+        sWriterFactory: sWriterFactory,
+        client: client,
+      );
+
+      final info = RequestInformation(
+        httpMethod: HttpMethod.get,
+        urlTemplate: 'https://example.test/primitive',
+      );
+
+      when(authProvider.authenticateRequest(info))
+          .thenAnswer((_) async => Future<void>.value());
+
+      when(client.send(any)).thenAnswer((_) async {
+        return http.StreamedResponse(
+          Stream.fromIterable([contentBytes]),
+          200,
+          headers: {
+            'content-type': 'text/plain',
+          },
+        );
+      });
+
+      when(pNodeFactory.getRootParseNode('text/plain', contentBytes))
+          .thenReturn(parseNode);
+
+      when(parseNode.getStringValue()).thenReturn(stringContent);
+
+      expect(
+            () => adapter.sendPrimitive<Object?>(info),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 }

--- a/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
+++ b/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
@@ -151,7 +151,7 @@ void main() {
       when(parseNode.getStringValue()).thenReturn(stringContent);
 
       expect(
-            () => adapter.sendPrimitive<Object?>(info),
+        () => adapter.sendPrimitive<Object?>(info),
         throwsA(isA<ArgumentError>()),
       );
     });

--- a/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
+++ b/packages/microsoft_kiota_http/test/http_client_request_adapter_test.dart
@@ -63,5 +63,51 @@ void main() {
       expect(stringResult, isNotNull);
       expect(stringResult, stringContent);
     });
+
+    test('sendPrimitive nullable String', () async {
+      final client = MockClient();
+      final authProvider = MockAuthenticationProvider();
+      final pNodeFactory = MockParseNodeFactory();
+      final sWriterFactory = MockSerializationWriterFactory();
+      final parseNode = MockParseNode();
+
+      const stringContent = 'Hello, World!';
+      final contentBytes = Uint8List.fromList(stringContent.codeUnits);
+
+      final adapter = HttpClientRequestAdapter(
+        authProvider: authProvider,
+        pNodeFactory: pNodeFactory,
+        sWriterFactory: sWriterFactory,
+        client: client,
+      );
+
+      final info = RequestInformation(
+        httpMethod: HttpMethod.get,
+        urlTemplate: 'https://example.test/primitive',
+      );
+
+      when(authProvider.authenticateRequest(info))
+          .thenAnswer((_) async => Future<void>.value());
+
+      when(client.send(any)).thenAnswer((_) async {
+        return http.StreamedResponse(
+          Stream.fromIterable([contentBytes]),
+          200,
+          headers: {
+            'content-type': 'text/plain',
+          },
+        );
+      });
+
+      when(pNodeFactory.getRootParseNode('text/plain', contentBytes))
+          .thenReturn(parseNode);
+
+      when(parseNode.getStringValue()).thenReturn(stringContent);
+
+      final stringResult = await adapter.sendPrimitive<String?>(info);
+
+      expect(stringResult, isNotNull);
+      expect(stringResult, stringContent);
+    });
   });
 }


### PR DESCRIPTION
This fixes #85.

Thanks to @mateusfccp for helping me figure this out!

---

I added special subtype checks for `DateOnly` and `TimeOnly` because those two are interfaces that might have third-party implementations.