### PR TITLE
Remove not-yet-published package from manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,6 @@
   "packages/microsoft_kiota_abstractions": "0.0.2",
   "packages/microsoft_kiota_bundle": "0.1.0",
   "packages/microsoft_kiota_http": "0.0.5",
-  "packages/microsoft_kiota_oauth": "0.0.1-preview1",
   "packages/microsoft_kiota_serialization_form": "0.0.2",
   "packages/microsoft_kiota_serialization_json": "0.0.3",
   "packages/microsoft_kiota_serialization_multipart": "0.0.2",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,7 @@
   "packages/microsoft_kiota_abstractions": "0.0.2",
   "packages/microsoft_kiota_bundle": "0.1.0",
   "packages/microsoft_kiota_http": "0.0.5",
+  "packages/microsoft_kiota_oauth": "0.0.1",
   "packages/microsoft_kiota_serialization_form": "0.0.2",
   "packages/microsoft_kiota_serialization_json": "0.0.3",
   "packages/microsoft_kiota_serialization_multipart": "0.0.2",


### PR DESCRIPTION
This should cause release please to publish the initial version of 0.0.1 for the new oauth package