### PR TITLE
Fixing type 'int' is not a subtype of type 'double' in type cast

### DIFF
--- a/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
@@ -92,7 +92,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   double? getDoubleValue() {
-    return _node as double;
+    return _node == null ? null : _node as double;
   }
 
   @override
@@ -112,7 +112,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   int? getIntValue() {
-    return _node as int;
+    return _node == null ? null : _node as int;
   }
 
   @override

--- a/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
@@ -92,7 +92,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   double? getDoubleValue() {
-    return _node == null ? null : _node as double;
+    return _node == null ? null : double.parse(_node.toString());
   }
 
   @override
@@ -112,7 +112,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   int? getIntValue() {
-    return _node == null ? null : _node as int;
+    return _node == null ? null : int.parse(_node.toString());
   }
 
   @override

--- a/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_parse_node.dart
@@ -92,7 +92,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   double? getDoubleValue() {
-    return _node == null ? null : double.parse(_node.toString());
+    return _node == null ? null : double.tryParse(_node.toString());
   }
 
   @override
@@ -112,7 +112,7 @@ class JsonParseNode implements ParseNode {
 
   @override
   int? getIntValue() {
-    return _node == null ? null : int.parse(_node.toString());
+    return _node == null ? null : int.tryParse(_node.toString());
   }
 
   @override

--- a/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
+++ b/packages/microsoft_kiota_serialization_json/test/json_parse_node_test.dart
@@ -201,5 +201,27 @@ void main() {
 
       expect(jsonParseNode.getBoolValue(), equals(null));
     });
+    test('getDoubleValue', () {
+      final jsonParseNode = JsonParseNode(jsonDecode('1.5'));
+
+      expect(jsonParseNode.getDoubleValue(), equals(1.5));
+    });
+
+    test('getDoubleValue with null', () {
+      final jsonParseNode = JsonParseNode(null);
+
+      expect(jsonParseNode.getDoubleValue(), equals(null));
+    });
+    test('getIntValue', () {
+      final jsonParseNode = JsonParseNode(jsonDecode('1'));
+
+      expect(jsonParseNode.getIntValue(), equals(1));
+    });
+
+    test('getIntValue with null', () {
+      final jsonParseNode = JsonParseNode(null);
+
+      expect(jsonParseNode.getIntValue(), equals(null));
+    });
   });
 }


### PR DESCRIPTION
A problem appearing when converting double? when it's nullable it's throwing

```
Unhandled exception:
type 'int' is not a subtype of type 'double' in type cast
#0      JsonParseNode.getDoubleValue (package:microsoft_kiota_serialization_json/src/json_parse_node.dart:95:18)
#1      MyModel.Eval ()
#2      MyModel.getFieldDeserializers.<anonymous closure> (<Private>)
#3      JsonParseNode._assignFieldValues (package:microsoft_kiota_serialization_json/src/json_parse_node.dart:152:29)
#4      JsonParseNode.getObjectValue (package:microsoft_kiota_serialization_json/src/json_parse_node.dart:126:5)
#5      JsonParseNode.getCollectionOfObjectValues (package:microsoft_kiota_serialization_json/src/json_parse_node.dart:64:34)
```

So simple update just said Pull request would be better than issue