### PR TITLE
Fixing UntypedNode sub json

### DIFF
--- a/packages/microsoft_kiota_serialization_json/lib/src/json_serialization_writer.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_serialization_writer.dart
@@ -151,8 +151,9 @@ class JsonSerializationWriter implements SerializationWriter {
     if (value != null) {
       onBeforeObjectSerialization?.call(value);
     }
+    final hasBodyContent = (key?.isNotEmpty ?? false) && value is! UntypedNode;
     var originalContents = <String, dynamic>{};
-    if (key?.isNotEmpty ?? false) {
+    if (hasBodyContent) {
       originalContents = {..._contents};
       _contents.clear();
     }
@@ -176,7 +177,7 @@ class JsonSerializationWriter implements SerializationWriter {
         }
       }
     }
-    if (key?.isNotEmpty ?? false) {
+    if (hasBodyContent) {
       final objectContents = {..._contents};
       _contents
         ..clear()

--- a/packages/microsoft_kiota_serialization_json/test/json_serialization_writer_test.dart
+++ b/packages/microsoft_kiota_serialization_json/test/json_serialization_writer_test.dart
@@ -4,6 +4,7 @@ import 'package:microsoft_kiota_serialization_json/microsoft_kiota_serialization
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
+import 'filter_request.dart';
 import 'microsoft_graph_group.dart';
 import 'microsoft_graph_user.dart';
 
@@ -46,6 +47,7 @@ void main() {
         ..workDuration = const Duration(hours: 40)
         ..birthDay =
             DateOnly.fromDateTime(DateTime.parse('2024-10-01 00:00:00'))
+        ..birthDay = DateOnly.fromDateTime(DateTime.parse('2024-10-01 00:00:00'))
         ..heightInMetres = 1.7
         ..startWorkTime = TimeOnly.fromDateTimeString('06:00')
         ..active = true
@@ -137,5 +139,57 @@ void main() {
         ),
       );
     });
+    test('writeAdditionalDataTypes', () {
+      final user2 = MicrosoftGraphUser()
+        ..workDuration = const Duration(hours: 12)
+        ..active = true;
+      final user = MicrosoftGraphUser()
+        ..officeLocation = ''
+        ..workDuration = const Duration(hours: 2)
+        ..additionalData = {
+          'a': '#1 coworker',
+          'string': 'a string',
+          'double': 0.0,
+          'bool': false,
+          'time': TimeOnly.fromComponents(12, 00),
+          'date': DateOnly.fromComponents(2000),
+          'datetime': DateTime(2024, 12, 31, 23, 59),
+          'uuid': UuidValue.fromString('019329eb-0ac5-7cc0-9dea-6440b3648264'),
+          'user': user2,
+        };
+
+      final writer = JsonSerializationWriter()
+        ..writeObjectValue(
+          null,
+          user,
+        );
+
+      expect(
+        utf8.decode(writer.getSerializedContent()),
+        equals(
+          '{"workDuration":"2:00:00.000000","a":"#1 coworker","string":"a string","double":0.0,"bool":false,"time":"12:00:00","date":"2000-01-01","datetime":"2024-12-31T23:59:00.000","uuid":"019329eb-0ac5-7cc0-9dea-6440b3648264","user":{"workDuration":"12:00:00.000000","active":true}}',
+        ),
+      );
+    });
+  });
+  test('writeUntypedNode', () {
+    var filterRequest = FilterRequest(
+      fieldName: 'name',
+      operator: 'contains',
+      value: UntypedString('jo'),
+    );
+
+    final writer = JsonSerializationWriter()
+      ..writeObjectValue(
+        null,
+        filterRequest,
+      );
+
+    expect(
+      utf8.decode(writer.getSerializedContent()),
+      equals(
+        '{"fieldName":"name","operator":"contains","value":"jo"}',
+      ),
+    );
   });
 }


### PR DESCRIPTION
UntypedNode like UntypedString the result like this "value":{"value":"jo"} instead of "value":"jo"
Before the changes
```
00:00 +37 -1: test\json_serialization_writer_test.dart: writeUntypedNode [E]
  Expected: '{"fieldName":"name","operator":"contains","value":"jo"}'
    Actual: '{"fieldName":"name","operator":"contains","value":{"value":"jo"}}'
     Which: is different.
            Expected: ... ","value":"jo"}
              Actual: ... ","value":{"value":" ...
                                    ^
             Differ at offset 50

  package:matcher                                 expect
  test\json_serialization_writer_test.dart 186:5  main.<fn>
```
After
```
Built test:test.
00:01 +36: All tests passed!
```