### PR TITLE
fix: parse primitives based on their type

### DIFF
--- a/packages/microsoft_kiota_serialization_json/lib/microsoft_kiota_serialization_json.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/microsoft_kiota_serialization_json.dart
@@ -7,7 +7,9 @@ library microsoft_kiota_serialization_json;
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:iso_duration/iso_duration.dart' as iso_duration;
 import 'package:microsoft_kiota_abstractions/microsoft_kiota_abstractions.dart';
+import 'package:microsoft_kiota_serialization_json/src/json_parse_exception.dart';
 import 'package:uuid/uuid_value.dart';
 
 part 'src/json_parse_node.dart';

--- a/packages/microsoft_kiota_serialization_json/lib/src/json_parse_exception.dart
+++ b/packages/microsoft_kiota_serialization_json/lib/src/json_parse_exception.dart
@@ -1,0 +1,17 @@
+﻿import 'package:microsoft_kiota_serialization_json/microsoft_kiota_serialization_json.dart';
+
+/// An [Exception] that is thrown when a [JsonParseNode] fails to deserialize
+/// a node.
+class JsonParseException implements Exception {
+  /// Creates a new [JsonParseException].
+  const JsonParseException({
+    required this.message,
+    required this.node,
+  });
+
+  /// The message explaining what went wrong.
+  final String message;
+
+  /// The node that caused the exception.
+  final JsonParseNode node;
+}

--- a/packages/microsoft_kiota_serialization_json/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_json/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  iso_duration: ^0.1.1
   microsoft_kiota_abstractions: ^0.0.1
   uuid: ^4.5.1
 


### PR DESCRIPTION
Fixes #105.

Previsouly, the `JsonParseNode` simply casted the list items to the generic type `T`.

This doesn't work for more complex types, like `DateTime` or `UuidValue`.

In this PR, I added a type check and individual handling for each type.
This also adds test cases for almost every type that can be parsed along some negative checks.